### PR TITLE
Swipe palette v2

### DIFF
--- a/.idea/panic-painter.iml
+++ b/.idea/panic-painter.iml
@@ -1,9 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
-    <exclude-output />
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>
+<module classpath="CMake" type="CPP_MODULE" version="4" />

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -176,16 +176,14 @@ void ColorPaletteView::update() {
             currButton->setPositionX(this->_computeXPositioning(_selectedColor));
             _selectedColor -= 1;
         } else {
-            if (moved && otherButton != nullptr) {
-                otherButton->setPositionX(this->_computeXPositioning(_selectedColor + (up ? 1 : -1)));
-            }
             for (uint i = 0; i < _colors.size(); i++) {
-                //_buttons[i]->setPositionX(this->_computeXPositioning(i));
-                Animation::alloc(
-                    _buttons[i], .1,
-                    {{ "positionX", this->_computeXPositioning(i) }},
-                    STRONG_OUT
-                );
+                if (i != _selectedColor) {
+                    Animation::alloc(
+                        _buttons[i], .1,
+                        {{ "positionX", this->_computeXPositioning(i) }},
+                        STRONG_OUT
+                    );
+                }
             }
             currButton->setPositionX(this->_computeXPositioning(_selectedColor) + 50);
         }

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -59,7 +59,7 @@ void ColorPaletteView::_setup() {
         btn->setContentSize(PALETTE_COLOR_SIZE, PALETTE_COLOR_SIZE);
         btn->setAnchor(Vec2::ANCHOR_CENTER);
         btn->setPosition(
-            btnStartX - (PADDING + PALETTE_COLOR_SIZE / 2) * i * i * curvature,
+            btnStartX - (PADDING + PALETTE_COLOR_SIZE / 2) * i * i * curvature + (i == 0 ? 50 : 0),
             btnStartY - (PADDING + PALETTE_COLOR_SIZE / 2) * i * PRESSED_SCALE
         );
         btn->setColor(_colors[i]);
@@ -82,16 +82,29 @@ void ColorPaletteView::_setup() {
 
 void ColorPaletteView::_animateButtonState(uint ind, const ColorButtonState s) {
     if (_buttonStates[ind] == s) return;
+    ColorButtonState oldState = _buttonStates[ind];
     _buttonStates[ind] = s;
-
+    float btnStartX = getContentWidth() - 35;
+    float originalX = btnStartX - (PADDING + PALETTE_COLOR_SIZE / 2) * ind * ind * 0.15;
     float scale = s == INACTIVE ?
         INACTIVE_SCALE :
         (s == PRESSED ? PRESSED_SCALE : 1);
+    float newX;
+    if (oldState == ACTIVE && s == PRESSED) {
+        newX = originalX + 50;
+    } else if (oldState == INACTIVE & s == PRESSED) {
+        newX = originalX;
+    } else if (s == ACTIVE) {
+        newX = originalX + 50;
+    } else {
+        newX = originalX;
+    }
     Animation::alloc(
         _buttons[ind], .2,
         {
             {"scaleX", scale},
-            {"scaleY", scale}
+            {"scaleY", scale},
+            {"positionX", newX}
         },
         STRONG_OUT
     );

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -153,7 +153,7 @@ void ColorPaletteView::update() {
     ptr<PolygonNode> otherButton = nullptr;
     bool moved = false;
     bool up = false;
-    if (input.hasMoved()) {
+    if (startingPointIn && input.isPressing()) {
         moved = true;
         if (diff > 0 && _selectedColor > 0) {
             otherButton = _buttons[_selectedColor - 1];

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -180,7 +180,12 @@ void ColorPaletteView::update() {
                 otherButton->setPositionX(this->_computeXPositioning(_selectedColor + (up ? 1 : -1)));
             }
             for (uint i = 0; i < _colors.size(); i++) {
-                _buttons[i]->setPositionX(this->_computeXPositioning(i));
+                //_buttons[i]->setPositionX(this->_computeXPositioning(i));
+                Animation::alloc(
+                    _buttons[i], .1,
+                    {{ "positionX", this->_computeXPositioning(i) }},
+                    STRONG_OUT
+                );
             }
             currButton->setPositionX(this->_computeXPositioning(_selectedColor) + 50);
         }

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -37,9 +37,7 @@ ptr<ColorPaletteView> ColorPaletteView::alloc(
 }
 
 float ColorPaletteView::_computeXPositioning(uint ind) {
-    return getContentWidth() - NEGATIVE_MARGIN_LEFT_WO_LAYOUT * PALETTE_WIDTH -
-    35 - (PADDING + PALETTE_COLOR_SIZE / 2) * ind
-    * ind * CURVATURE;
+    return getContentWidth() - 35 - (PADDING + PALETTE_COLOR_SIZE / 2) * ind * ind * CURVATURE;
 }
 
 void ColorPaletteView::_setup() {
@@ -49,8 +47,7 @@ void ColorPaletteView::_setup() {
     auto bg = PolygonNode::allocWithTexture(_paletteTexture);
     bg->setAnchor(Vec2::ANCHOR_BOTTOM_LEFT);
     bg->setContentSize(PALETTE_WIDTH, PALETTE_HEIGHT);
-    bg->setPositionX(-(NEGATIVE_MARGIN_LEFT + NEGATIVE_MARGIN_LEFT_WO_LAYOUT)
-    * bg->getContentWidth());
+    bg->setPositionX(-NEGATIVE_MARGIN_LEFT * bg->getContentWidth());
     setContentSize(bg->getContentWidth() * (1 - NEGATIVE_MARGIN_LEFT),
                    bg->getContentHeight());
 

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -15,10 +15,6 @@
 #define PRESSED_SCALE 1.2f
 #define PALETTE_WIDTH 190
 #define PALETTE_HEIGHT 260
-#define NEGATIVE_MARGIN_LEFT_WO_LAYOUT 0.2f /* = 20% of PALETTE_WIDTH */
-// The difference between the one above and below is that if you increase the
-// value below, the palette will enlarge to try to fill the container space.
-// The one above wouldn't do that.
 #define NEGATIVE_MARGIN_LEFT 0.4f /* = 40% of PALETTE_WIDTH */
 #define CURVATURE 0.15 /** Curvature constant for the palette. */
 

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -101,7 +101,7 @@ void ColorPaletteView::_animateButtonState(uint ind, const ColorButtonState s) {
     float newX;
     if (oldState == ACTIVE && s == PRESSED) {
         newX = originalX + 50;
-    } else if (oldState == INACTIVE & s == PRESSED) {
+    } else if (oldState == INACTIVE && s == PRESSED) {
         newX = originalX;
     } else if (s == ACTIVE) {
         newX = originalX + 50;

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -126,6 +126,20 @@ void ColorPaletteView::update() {
         for (uint i = 0, j = (uint) _colors.size(); i < j; i++)
             _animateButtonState(i, _selectedColor == i ? ACTIVE : INACTIVE);
     }
+    
+    // Enable swipe up/down on palette for color switching.
+    Vec2 sp = input.startingPoint();
+    bool startingPointIn = InputController::inScene(sp, getBoundingBox());
+    
+    Vec2 cp = input.currentPoint();
+    if (startingPointIn && input.justReleased()) {
+        if (sp.y - cp.y > 50 && _selectedColor < _colors.size() - 1) {
+            _selectedColor += 1;
+        } else if (cp.y - sp.y > 50 && _selectedColor > 0) {
+            _selectedColor -= 1;
+        }
+    }
+    
 }
 
 

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -176,10 +176,13 @@ void ColorPaletteView::update() {
             currButton->setPositionX(this->_computeXPositioning(_selectedColor));
             _selectedColor -= 1;
         } else {
-            currButton->setPositionX(this->_computeXPositioning(_selectedColor) + 50);
             if (moved && otherButton != nullptr) {
                 otherButton->setPositionX(this->_computeXPositioning(_selectedColor + (up ? 1 : -1)));
             }
+            for (uint i = 0; i < _colors.size(); i++) {
+                _buttons[i]->setPositionX(this->_computeXPositioning(i));
+            }
+            currButton->setPositionX(this->_computeXPositioning(_selectedColor) + 50);
         }
     }
     

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -15,6 +15,10 @@
 #define PRESSED_SCALE 1.2f
 #define PALETTE_WIDTH 190
 #define PALETTE_HEIGHT 260
+#define NEGATIVE_MARGIN_LEFT_WO_LAYOUT 0.2f /* = 20% of PALETTE_WIDTH */
+// The difference between the one above and below is that if you increase the
+// value below, the palette will enlarge to try to fill the container space.
+// The one above wouldn't do that.
 #define NEGATIVE_MARGIN_LEFT 0.4f /* = 40% of PALETTE_WIDTH */
 #define CURVATURE 0.15 /** Curvature constant for the palette. */
 
@@ -33,7 +37,9 @@ ptr<ColorPaletteView> ColorPaletteView::alloc(
 }
 
 float ColorPaletteView::_computeXPositioning(uint ind) {
-    return getContentWidth() - 35 - (PADDING + PALETTE_COLOR_SIZE / 2) * ind * ind * CURVATURE;
+    return getContentWidth() - NEGATIVE_MARGIN_LEFT_WO_LAYOUT * PALETTE_WIDTH -
+    35 - (PADDING + PALETTE_COLOR_SIZE / 2) * ind
+    * ind * CURVATURE;
 }
 
 void ColorPaletteView::_setup() {
@@ -43,7 +49,8 @@ void ColorPaletteView::_setup() {
     auto bg = PolygonNode::allocWithTexture(_paletteTexture);
     bg->setAnchor(Vec2::ANCHOR_BOTTOM_LEFT);
     bg->setContentSize(PALETTE_WIDTH, PALETTE_HEIGHT);
-    bg->setPositionX(-NEGATIVE_MARGIN_LEFT * bg->getContentWidth());
+    bg->setPositionX(-(NEGATIVE_MARGIN_LEFT + NEGATIVE_MARGIN_LEFT_WO_LAYOUT)
+    * bg->getContentWidth());
     setContentSize(bg->getContentWidth() * (1 - NEGATIVE_MARGIN_LEFT),
                    bg->getContentHeight());
 

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -69,7 +69,7 @@ void ColorPaletteView::_setup() {
         btn->setContentSize(PALETTE_COLOR_SIZE, PALETTE_COLOR_SIZE);
         btn->setAnchor(Vec2::ANCHOR_CENTER);
         btn->setPosition(
-            this->_computeXPositioning(i) + (i == 0 ? 50 : 0),
+            this->_computeXPositioning(i),
             btnStartY - (PADDING + PALETTE_COLOR_SIZE / 2) * i * PRESSED_SCALE
         );
         btn->setColor(_colors[i]);
@@ -92,28 +92,15 @@ void ColorPaletteView::_setup() {
 
 void ColorPaletteView::_animateButtonState(uint ind, const ColorButtonState s) {
     if (_buttonStates[ind] == s) return;
-    ColorButtonState oldState = _buttonStates[ind];
     _buttonStates[ind] = s;
-    float originalX = this->_computeXPositioning(ind);
     float scale = s == INACTIVE ?
         INACTIVE_SCALE :
         (s == PRESSED ? PRESSED_SCALE : 1);
-    float newX;
-    if (oldState == ACTIVE && s == PRESSED) {
-        newX = originalX + 50;
-    } else if (oldState == INACTIVE && s == PRESSED) {
-        newX = originalX;
-    } else if (s == ACTIVE) {
-        newX = originalX + 50;
-    } else {
-        newX = originalX;
-    }
     Animation::alloc(
         _buttons[ind], .2,
         {
             {"scaleX", scale},
             {"scaleY", scale},
-            {"positionX", newX}
         },
         STRONG_OUT
     );
@@ -146,18 +133,17 @@ void ColorPaletteView::update() {
         if (startingPointIn && input.isPressing()) {
             indexOfOtherColor = this->_computeColorIndexAfterSwipe(diff);
             for (uint i = 0; i < _colors.size(); i++) {
-                if (i != indexOfOtherColor && _buttonStates[i] != ACTIVE) {
                     Animation::alloc(
                         _buttons[i], .3,
-                        {{ "positionX", this->_computeXPositioning(i) }},
+                        {{ "scaleX", INACTIVE_SCALE }, { "scaleY", INACTIVE_SCALE }},
                         STRONG_OUT
                     );
-                }
             }
             
             Animation::alloc(
                 _buttons[indexOfOtherColor], .3,
-                {{ "positionX", this->_computeXPositioning(indexOfOtherColor) + 50 }},
+                {{"scaleX", PRESSED_SCALE},
+                {"scaleY", PRESSED_SCALE}},
                 STRONG_OUT
             );
         }
@@ -190,7 +176,6 @@ void ColorPaletteView::update() {
     }
     
     // Enable swipe up/down on palette for color switching.
-    
     if (startingPointIn && input.justReleased()) {
         indexOfOtherColor = this->_computeColorIndexAfterSwipe(diff);
         if (indexOfOtherColor != -1 && indexOfOtherColor != _selectedColor) {

--- a/source/scenes/gameplay/PPColorPaletteView.h
+++ b/source/scenes/gameplay/PPColorPaletteView.h
@@ -45,6 +45,8 @@ class ColorPaletteView : public SceneNode {
     
     float _computeXPositioning(uint ind);
     
+    uint _computeColorIndexAfterSwipe(float diff);
+    
 public:
     /** @deprecated Constructor. */
     explicit ColorPaletteView(const vec<Color4> &colors,

--- a/source/scenes/gameplay/PPColorPaletteView.h
+++ b/source/scenes/gameplay/PPColorPaletteView.h
@@ -43,6 +43,8 @@ class ColorPaletteView : public SceneNode {
 
     void _animateButtonState(uint ind, ColorButtonState s);
     
+    float _computeXPositioning(uint ind);
+    
 public:
     /** @deprecated Constructor. */
     explicit ColorPaletteView(const vec<Color4> &colors,


### PR DESCRIPTION
This PR integrates a continuous swipe mechanism to give the palette a slider-effect. A player can press anywhere in the canvas and drag their finger up or down to go through different colors, and release to select that color. Right now, to get to a selected color, the player needs to release their finger to actually switch to that color, but since we haven't tackled multitouch yet, we can think about this later. This version will work for alpha.    