### PR TITLE
Fix level select safe space issue

### DIFF
--- a/source/scenes/level/PPLevelSelectScene.cpp
+++ b/source/scenes/level/PPLevelSelectScene.cpp
@@ -56,6 +56,9 @@ void LevelSelectScene::activateUI(
     if (button != nullptr) {
 //        CULog("Activating button %s", button->getName().c_str());
         if (button->getName() == "menubutton") {
+            Rect safeArea = Application::get()->getSafeBounds();
+            button->setAnchor(Vec2::ANCHOR_TOP_LEFT);
+            button->setPosition(0, safeArea.size.height);
             button->addListener([=](const string &name, bool down) {
                 if (!down) {
                     _state = BACK;
@@ -70,6 +73,10 @@ void LevelSelectScene::activateUI(
             });
         }
         button->activate();
+        
+        // Fix positioning to safe area
+        //Rect safeArea = Application::get()->getSafeBounds();
+        //if(button->getPositionY  button->setPositionY
     } else {
         // Go deeper
         for (Uint32 ii = 0; ii < scene->getChildCount(); ii++) {

--- a/source/scenes/level/PPLevelSelectScene.cpp
+++ b/source/scenes/level/PPLevelSelectScene.cpp
@@ -6,13 +6,6 @@ bool LevelSelectScene::init(const asset_t &assets) {
     // Initialize the scene to a locked width
     Size screenSize = Application::get()->getDisplaySize();
 
-    // Lock the scene to a reasonable resolution
-    if (screenSize.width > screenSize.height) {
-        screenSize *= SCENE_SIZE / screenSize.width;
-    } else {
-        screenSize *= SCENE_SIZE / screenSize.height;
-    }
-
     if (assets == nullptr) {
         return false;
     } else if (!Scene2::init(screenSize)) {


### PR DESCRIPTION
_I think_ this should fix the level select safe space issue. I can't build on mobile rn so I can't test. Can someone with AS and someone with XCode test this?

This is what the issue originally looked like: 
![cutoff](https://user-images.githubusercontent.com/33598616/115260142-7b8f6880-a100-11eb-94ee-04abab851d06.png)

The menu button should be squarely within the safe space now.