### PR TITLE
Fix tap

### DIFF
--- a/source/controllers/PPInputController.cpp
+++ b/source/controllers/PPInputController.cpp
@@ -167,7 +167,4 @@ bool InputController::didTripleTap() const {
 
 void InputController::clearPreviousTaps() {
     _inputs.clear();
-    if (_currentInput != nullptr) {
-        _inputs.push_front(_currentInput);
-    }
 }

--- a/source/scenes/gameplay/PPColorPaletteView.cpp
+++ b/source/scenes/gameplay/PPColorPaletteView.cpp
@@ -157,6 +157,7 @@ void ColorPaletteView::update() {
             if (input.justReleased()) {
                 _selectedColor = i;
                 _animateButtonState(i, ACTIVE);
+                input.clearPreviousTaps(); 
             } else {
                 _animateButtonState(i, PRESSED);
             }


### PR DESCRIPTION
This PR fixes two input based bugs: the inconsistent double tap & the bug where you can tap the palette and then tap any canvas to get a double tap. 

Tested on windows & Bryan tested on android and it seems to now have consistent input behavior