### PR TITLE
Add level multiplier functionality

### DIFF
--- a/source/controllers/PPActionController.cpp
+++ b/source/controllers/PPActionController.cpp
@@ -1,4 +1,5 @@
 #include "PPActionController.h"
+#define LEVEL_MULTIPLIER_INCREMENT 0.1
 
 void ActionController::update(const set<pair<uint, uint>> &activeCanvases,
                               uint selectedColor) {
@@ -41,7 +42,12 @@ void ActionController::update(const set<pair<uint, uint>> &activeCanvases,
                     SoundController::getInstance()->playSfx("scribble");
                     int newColors = (int) _state.getColorsOfCanvas(i, i2).size();
                     if (newColors < prevColors) {
+                        CULog("Previous multiplier: %f", _state.getLevelMultiplier());
                         _state.incrementScoreForSwipe(1);
+                        _state.setLevelMultiplier(min(3.0f,
+                                                      (float)(_state.getLevelMultiplier()
+                                                              + LEVEL_MULTIPLIER_INCREMENT)));
+                        CULog("New multiplier: %f", _state.getLevelMultiplier());
                     }
                     input.clearPreviousTaps();
                 }
@@ -123,6 +129,14 @@ void ActionController::update(const set<pair<uint, uint>> &activeCanvases,
                 SoundController::getInstance()->playSfx("incorrect");
             }
             _state.incrementScoreForSwipe(1 + numCorrect * 1.5);
+            if (toClear.size() == numCorrect) {
+                CULog("Previous multiplier after swipe: %f", _state.getLevelMultiplier());
+                _state.setLevelMultiplier(min(3.0f,
+                                              (float)(_state.getLevelMultiplier() +
+                                                      LEVEL_MULTIPLIER_INCREMENT * numCorrect)));
+                CULog("New multiplier after swipe %f", _state.getLevelMultiplier());
+            }
+            
         }
     }
 }

--- a/source/controllers/PPGameStateController.cpp
+++ b/source/controllers/PPGameStateController.cpp
@@ -15,6 +15,7 @@ void GameStateController::_jsonv1_loadColors(const json_t &colors) {
     _state.scoreTracker["timedOut"] = 0;
     _state.scoreTracker["correct"] = 0;
     _state.scoreTracker["aggregateScore"] = 0;
+    _state.levelMultiplier = 1;
 }
 
 void GameStateController::_jsonv1_loadQueues(const json_t &queues) {
@@ -114,9 +115,11 @@ void GameStateController::update(float timestep) {
                 if (cs == LOST_DUE_TO_TIME) {
                     _state.scoreTracker["timedOut"]++;
                     _state.scoreTracker["aggregateScore"] -= 5;
+                    _state.levelMultiplier = 1;
                 } else if (cs == LOST_DUE_TO_WRONG_ACTION) {
                     _state.scoreTracker["wrongAction"]++;
                     _state.scoreTracker["aggregateScore"] -= 10;
+                    _state.levelMultiplier = 1;
                 } else {
                     _state.scoreTracker["correct"]++;
                 }
@@ -233,5 +236,14 @@ uint GameStateController::getScoreMetric(string type) const {
 }
 
 void GameStateController::incrementScoreForSwipe(float multiplier) {
-     _state.scoreTracker["aggregateScore"] += multiplier * 10;
- }
+     _state.scoreTracker["aggregateScore"] += _state.levelMultiplier * multiplier * 10;
+}
+
+float GameStateController::getLevelMultiplier() const {
+    return _state.levelMultiplier;
+}
+
+void GameStateController::setLevelMultiplier(float lm) {
+    CUAssertLog(lm <= 3.0f, "Cannot set the level multiplier to a value more than 3");
+    _state.levelMultiplier = lm;
+}

--- a/source/controllers/PPGameStateController.h
+++ b/source/controllers/PPGameStateController.h
@@ -94,6 +94,10 @@ public:
     uint getScoreMetric(string type) const;
     
     void incrementScoreForSwipe(float multiplier);
+    
+    float getLevelMultiplier() const;
+    
+    void setLevelMultiplier(float lm);
 };
 
 #endif //PANICPAINTER_PPGAMESTATECONTROLLER_H

--- a/source/models/PPGameState.h
+++ b/source/models/PPGameState.h
@@ -69,6 +69,9 @@ struct GameState {
      * as smart pointers so the timer itself can be updated freely.
      */
     vec<vec<ptr<Timer>>> canvasTimers;
+    
+    /** The level multiplier */
+    float levelMultiplier;
 };
 
 #endif //PANICPAINTER_PPGAMESTATE_H


### PR DESCRIPTION
Implement the Level Multiplier. 

THIS DOES NOT HAVE THE FRONTEND YET. You can see the level multiplier changing in the CULogs. 

- The level multiplier is set to 1 on any mistake (incorrect action OR timeout)
- The level multiplier is increased by 0.1 on every single tap 
- The level multiplier is increased by 0.1*(number of canvases swiped on) IF AND ONLY IF all the canvases in that swipe are correctly dismissed
- The maximum value a level timer can reach is 3. 