### PR TITLE
make health potion add a bit more plus add it back to the logic

### DIFF
--- a/source/controllers/PPGameStateController.cpp
+++ b/source/controllers/PPGameStateController.cpp
@@ -152,7 +152,7 @@ void GameStateController::update(float timestep) {
                 }
                 else {
                     if (cs == DONE) {
-                        _state.healthBack += 0.8;
+                        _state.healthBack += 1; 
                     }
                 }
                 _state.scoreTracker["aggregateScore"] = max(0, (int) _state.scoreTracker["aggregateScore"]);

--- a/source/scenes/gameplay/PPGameScene.cpp
+++ b/source/scenes/gameplay/PPGameScene.cpp
@@ -183,7 +183,7 @@ void GameScene::update(float timestep) {
     uint mul = round(_state.getLevelMultiplier() * 10) - 10;
 
     float health = 1 - (float)(_state.getScoreMetric("wrongAction") +
-        _state.getScoreMetric("timedOut")) /
+        _state.getScoreMetric("timedOut") - _state.getHealthBack()) /
             (_state.getState().nCanvasInLevel / 3);
     if (health < 0) health = 0;
     if (health > 1) health = 1;


### PR DESCRIPTION
During conversion to health bar, health potion didn't make it in. Adding it back in and removing the 0.8 math to make it a little more simple & add a bit more health. 

Tested on windows using island-1